### PR TITLE
running from starter project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+## Running HAPI server from source
+
+### Install prerequisites
+
+```
+brew install maven
+```
+
+### Clone the Starter project
+
+```
+git clone git@github.com:hapifhir/hapi-fhir-jpaserver-starter.git
+```
+
+### Run the HAPI server using Jetty
+
+```
+cd hapi-fhir-jpaserver-starter
+mvn -Pjetty jetty:run
+```

--- a/terminologies/import-loinc.sh
+++ b/terminologies/import-loinc.sh
@@ -1,6 +1,4 @@
-#!/bin/sh
-hapi-fhir-cli upload-terminology \
-    -d data/Loinc_2.76.zip \
-    -v r4 \
-    -t "http://localhost:8080/fhir" \
-    -u "http://loinc.org"
+## using Loinc v 2.72,
+## breaking changes in v 2.73
+## MultiAxialHierarchy/ becomes ComponentHierarchyBySystem/
+hapi-fhir-cli upload-terminology -d data/Loinc_2.72.zip -v r4 -t "http://localhost:8080/fhir" -u "http://loinc.org"

--- a/terminologies/import-snomed.sh
+++ b/terminologies/import-snomed.sh
@@ -1,0 +1,1 @@
+hapi-fhir-cli upload-terminology -d data/SnomedCT_ManagedServiceUS_PRODUCTION_US1000124_20230901T120000Z.zip -v r4 -t http://localhost:8080/fhir -u http://snomed.info/sct


### PR DESCRIPTION
# Why

_Because the docker either doesn't have a shell or doesn't have the hapi-fhir-cli tool, this is an easy stepping stone for local development that will later be Dockerizable_

## What was done
- [x] Provide instructions to run from starter project using the _Jetty_ server
- [x] fix `Loinc` import script
- [x] add snomed import script  