### PR TITLE
HAPI Dockerfile with insertion point for our script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+**/.DS_Store
+**/__pycache__
+**/.venv
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/bin
+**/charts
+**/docker-compose*
+**/compose*
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM bitnami/minideb:latest AS build-bonfhir
+FROM debian:bookworm-slim AS build-bonfhir
 
 RUN apt-get update && apt-get upgrade && apt-get install -y curl unzip
 RUN mkdir -p /usr/src/hapi-fhir-cli \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+
+FROM bitnami/minideb:latest AS build-bonfhir
+
+RUN apt-get update && apt-get upgrade && apt-get install -y curl unzip
+RUN mkdir -p /usr/src/hapi-fhir-cli \
+  && curl -SL https://github.com/hapifhir/hapi-fhir/releases/download/v6.10.3/hapi-fhir-6.10.3-cli.zip -o hapi-fhir-6.10.3-cli.zip \
+  && unzip -q hapi-fhir-6.10.3-cli.zip -d /usr/src/hapi-fhir-cli
+
+COPY <<EOF /bin/app.sh
+#!/bin/bash
+# This script is run when the container starts
+# It is used to start the application
+# the code system bootstrap script should be added around here
+cd /app && java --class-path /app/main.war -Dloader.path="main.war!/WEB-INF/classes/,main.war!/WEB-INF/,/app/extra-classes" org.springframework.boot.loader.PropertiesLauncher
+EOF
+
+FROM hapiproject/hapi:latest AS hapi-distroless
+
+FROM hapiproject/hapi:latest-tomcat AS bonfhir-hapi
+
+COPY --from=build-bonfhir --chown=1001:1001 /usr/src/hapi-fhir-cli /usr/src/hapi-fhir-cli
+COPY --from=build-bonfhir --chown=1001:1001 /bin/app.sh /bin/
+COPY --chown=1001:1001 --from=hapi-distroless /app /app
+RUN chmod a+x /bin/app.sh
+
+USER 1001
+
+ENTRYPOINT [ "/bin/app.sh" ]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM hapiproject/hapi:latest AS hapi-distroless
 
 FROM hapiproject/hapi:latest-tomcat AS bonfhir-hapi
 
-COPY --from=build-bonfhir --chown=1001:1001 /usr/src/hapi-fhir-cli /usr/src/hapi-fhir-cli
+COPY --from=build-bonfhir --chown=1001:1001 /usr/src/hapi-fhir-cli /usr/bin/
 COPY --from=build-bonfhir --chown=1001:1001 /bin/app.sh /bin/
 COPY --chown=1001:1001 --from=hapi-distroless /app /app
 RUN chmod a+x /bin/app.sh

--- a/build-and-run-docker-image.sh
+++ b/build-and-run-docker-image.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run --rm -it $(docker image build -q - < Dockerfile)

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker image build -q - < Dockerfile


### PR DESCRIPTION
# Why
_We need a starter Dockerfile, the meeting point of the HAPI server & our bootstrapping script execution environment_

## What was done

- [x] assemble a Dockerfile featuring a working _HAPI_ server
- [x] Install `hapi-fhir-cli` in that Docker 
- [x] control the `ENTRYPOINT` for both _HAPI_ server & bootstrapping script 