### PR TITLE
fix: adds missing script deps tput & curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,10 @@ cd /app && java --class-path /app/main.war -Dloader.path="main.war!/WEB-INF/clas
 EOF
 
 FROM hapiproject/hapi:latest AS hapi-distroless
-
 FROM hapiproject/hapi:latest-tomcat AS bonfhir-hapi
+
+USER root
+RUN apt update && apt install -y curl libncurses5-dev  # libncurses5-dev for tput
 
 COPY --from=build-bonfhir --chown=1001:1001 /usr/src/hapi-fhir-cli /usr/bin/
 COPY --from=build-bonfhir --chown=1001:1001 /bin/app.sh /bin/
@@ -27,4 +29,3 @@ RUN chmod a+x /bin/app.sh
 USER 1001
 
 ENTRYPOINT [ "/bin/app.sh" ]
-


### PR DESCRIPTION
# Why
_The code loading script requires tput & curl to be present_

## What was done
- [x] install `tput` in the docker image
- [x] install `curl` in the docker image 