### PR TITLE
Enable Relaxed Query Characters

### DIFF
--- a/mounts/configs/application.yml
+++ b/mounts/configs/application.yml
@@ -226,3 +226,7 @@ hapi:
 #  protocol: 'http'
 #  schema_management_strategy: CREATE
 #  username: SomeUsername
+
+server:
+  tomcat:
+    relaxed-query-chars: ["|", "[", "]"]

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -20,7 +20,6 @@ stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 
-
 [program:server-bootstrap]
 user=bonfhir
 directory=/bonfhir/server-setup


### PR DESCRIPTION
Fix for #20 

Add the `server.tomcat.relaxed-query-chars=|[]` property to spring boot to support FHIR Search Parameters in Tomcat.